### PR TITLE
Clean-up + Refactorings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Changed
+- `generate_template_setup_py` function in `reserver/functions.py`
+- `generate_template_pyproject_toml` function in `reserver/functions.py`
+- `params.py`
+- `__init__` method in `PyPIUploader`
+- `upload` method in `PyPIUploader`
+- Test system modified
 ## [0.7] - 2026-04-03
 ### Changed
 - `_run` function in `__main__.py`

--- a/reserver/functions.py
+++ b/reserver/functions.py
@@ -96,6 +96,8 @@ setup(
         \'Programming Language :: Python :: 3.10\',
         \'Programming Language :: Python :: 3.11\',
         \'Programming Language :: Python :: 3.12\',
+        \'Programming Language :: Python :: 3.13\',
+        \'Programming Language :: Python :: 3.14\',
     ],
     license=""" + "\"" + get_package_parameter("license", user_parameters) + "\"" + """,
 )
@@ -148,6 +150,8 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 dependencies = []  # Explicitly specify no dependencies
 requires-python = ">=3.6"

--- a/reserver/params.py
+++ b/reserver/params.py
@@ -18,6 +18,7 @@ VALIDATIONS = {
     "email": r'^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$',
     "url": r'^(http|https)://[a-zA-Z0-9.-_]+\.[a-zA-Z]{2,}(/\S*)?$',
 }
+MISSING_API_TOKEN_ERROR = "A non-empty PyPI API token (str) is required."
 INVALID_PACKAGE_PARAMETER_NAME_ERROR = "Given parameter doesn't exist among the supported user allowed parameters."
 INVALID_PACKAGE_PARAMETER_VALUE_ERROR = "Invalid value for {parameter} that should be a valid {regex}"
 INVALID_CONFIG_FILE_NAME_ERROR = "Given file name for user-defined package params is not a string."

--- a/reserver/params.py
+++ b/reserver/params.py
@@ -5,13 +5,14 @@ Reserver is an open source Python package that offers the ability to quickly res
 """
 RESERVER_VERSION = "0.7"
 RESERVER_NAME = "reserver"
+RESERVER_REPO_URL = "https://github.com/openscilab/reserver"
 PACKAGE_PARAMETERS = {
     "description": "This name has been reserved using Reserver",
     "author": "Development Team",
-    "author_email": "test@test.com",
-    "url": "https://url.com",
-    "download_url": "https://download_url.com",
-    "source": "https://github.com/source",
+    "author_email": "reserver@openscilab.com",
+    "url": RESERVER_REPO_URL,
+    "download_url": RESERVER_REPO_URL,
+    "source": RESERVER_REPO_URL,
     "license": "MIT",
 }
 VALIDATIONS = {

--- a/reserver/uploader.py
+++ b/reserver/uploader.py
@@ -3,11 +3,12 @@
 import chardet
 import platform
 from sys import executable
-from os import environ, path, getcwd
+from os import environ, path, getcwd, chdir
+from tempfile import mkdtemp
 from .errors import ReserverBaseError
 from .functions import generate_template_setup_py
 from subprocess import check_output, CalledProcessError, STDOUT
-from .params import UNEQUAL_PARAM_NAME_LENGTH_ERROR
+from .params import UNEQUAL_PARAM_NAME_LENGTH_ERROR, MISSING_API_TOKEN_ERROR
 from .params import MAIN_PYPI_REVOKE_TOKEN_MESSAGE, TEST_PYPI_REVOKE_TOKEN_MESSAGE
 from .utils import has_named_parameter, remove_dir, read_json
 
@@ -88,62 +89,69 @@ class PyPIUploader:
         if not isinstance(user_parameters, dict) and user_parameters is not None:
             user_parameters = read_json(user_parameters)
 
-        environ["TWINE_USERNAME"] = self.username
-        environ["TWINE_PASSWORD"] = self.password
-
-        package_path = path.join(getcwd(), package_name)
-        generated_dist_folder = path.join(package_path, "dist")
-        generated_tar_gz_file = path.join(generated_dist_folder, "*.tar.gz")
-        generated_wheel_file = path.join(generated_dist_folder, "*.whl")
-        # prevent from uploading any other previously build library in this path.
-        remove_dir(generated_dist_folder)
-        build_command = f'"{executable}" -m build "{package_path}" --sdist --wheel'
-        if platform.system() == "Windows":
-            commands = [f'{build_command} > nul 2>&1']
-        else:
-            commands = [f'{build_command} > /dev/null 2>&1']
-        if self.test_pypi:
-            commands += [
-                f'"{executable}" -m twine upload --repository testpypi "{generated_tar_gz_file}"',
-                f'"{executable}" -m twine upload --repository testpypi "{generated_wheel_file}"',
-            ]
-        else:
-            commands += [
-                f'"{executable}" -m twine upload "{generated_tar_gz_file}"',
-                f'"{executable}" -m twine upload "{generated_wheel_file}"',
-            ]
-        # Run the commands
         publish_failed = False
         error = None
+        original_cwd = getcwd()
+        workdir = mkdtemp(prefix="reserver-")
 
-        generate_template_setup_py(package_name, user_parameters)
+        # Build a per-call env copy so credentials exist only in the subprocess
+        # environment, never in this process's os.environ. Thread-safe and leak-free.
+        upload_env = environ.copy()
+        upload_env["TWINE_USERNAME"] = self.username
+        upload_env["TWINE_PASSWORD"] = self.password
 
-        for command in commands:
-            try:
-                if has_named_parameter(check_output, "text"):
-                    check_output(command, shell=True, text=True, stderr=STDOUT)
-                else:
-                    check_output(command, shell=True, stderr=STDOUT)
-            except CalledProcessError as e:
-                publish_failed = True
-                error = e.output
-                if not error:
-                    error = "Unknown error (no output captured)"
-                elif isinstance(error, bytes):
-                    fallback = 'utf-8'
-                    try:
-                        encoding = (chardet.detect(error) or {}).get('encoding') or fallback
-                        error = error.decode(encoding)
-                    except (UnicodeDecodeError, LookupError):
-                        error = error.decode(fallback, errors='replace')
+        try:
+            # build the template package inside an isolated temp dir to avoid
+            # touching (or deleting) any same-named directory in the user's CWD
+            chdir(workdir)
 
-        # remove credential from env variables
-        if "TWINE_USERNAME" in environ:
-            environ.pop("TWINE_USERNAME")
-        if "TWINE_PASSWORD" in environ:
-            environ.pop("TWINE_PASSWORD")
-        # remove previously generated files
-        remove_dir(package_path)
+            package_path = path.join(workdir, package_name)
+            generated_dist_folder = path.join(package_path, "dist")
+            generated_tar_gz_file = path.join(generated_dist_folder, "*.tar.gz")
+            generated_wheel_file = path.join(generated_dist_folder, "*.whl")
+            build_command = f'"{executable}" -m build "{package_path}" --sdist --wheel'
+            if platform.system() == "Windows":
+                commands = [f'{build_command} > nul 2>&1']
+            else:
+                commands = [f'{build_command} > /dev/null 2>&1']
+            if self.test_pypi:
+                commands += [
+                    f'"{executable}" -m twine upload --repository testpypi "{generated_tar_gz_file}"',
+                    f'"{executable}" -m twine upload --repository testpypi "{generated_wheel_file}"',
+                ]
+            else:
+                commands += [
+                    f'"{executable}" -m twine upload "{generated_tar_gz_file}"',
+                    f'"{executable}" -m twine upload "{generated_wheel_file}"',
+                ]
+
+            generate_template_setup_py(package_name, user_parameters)
+
+            for command in commands:
+                try:
+                    if has_named_parameter(check_output, "text"):
+                        check_output(command, shell=True, text=True, stderr=STDOUT, env=upload_env)
+                    else:
+                        check_output(command, shell=True, stderr=STDOUT, env=upload_env)
+                except CalledProcessError as e:
+                    publish_failed = True
+                    error = e.output
+                    if not error:
+                        error = "Unknown error (no output captured)"
+                    elif isinstance(error, bytes):
+                        fallback = 'utf-8'
+                        try:
+                            encoding = (chardet.detect(error) or {}).get('encoding') or fallback
+                            error = error.decode(encoding)
+                        except (UnicodeDecodeError, LookupError):
+                            error = error.decode(fallback, errors='replace')
+                    # stop on the first failure so we report the actual cause
+                    # instead of overwriting `error` with follow-up twine failures
+                    break
+        finally:
+            # always restore CWD and clean the temp dir
+            chdir(original_cwd)
+            remove_dir(workdir)
 
         if publish_failed:
             safe_error = error.encode('ascii', errors='replace').decode('ascii')

--- a/reserver/uploader.py
+++ b/reserver/uploader.py
@@ -94,9 +94,13 @@ class PyPIUploader:
         original_cwd = getcwd()
         workdir = mkdtemp(prefix="reserver-")
 
-        # Build a per-call env copy so credentials exist only in the subprocess
-        # environment, never in this process's os.environ. Thread-safe and leak-free.
-        upload_env = environ.copy()
+        # Build a per-call env for the subprocess:
+        #   * inherit everything non-TWINE from the parent (PATH, HOME, proxies, etc.)
+        #   * strip any pre-existing TWINE_* so parent-set vars like
+        #     TWINE_REPOSITORY_URL can't redirect reserver's upload
+        #   * inject reserver's own credentials
+        # os.environ itself is never mutated (thread-safe, leak-free).
+        upload_env = {k: v for k, v in environ.items() if not k.startswith("TWINE_")}
         upload_env["TWINE_USERNAME"] = self.username
         upload_env["TWINE_PASSWORD"] = self.password
 

--- a/reserver/uploader.py
+++ b/reserver/uploader.py
@@ -30,6 +30,8 @@ class PyPIUploader:
         :type test_pypi: bool
         :return: an instance of the Reserver PyPIUploader
         """
+        if not isinstance(api_token, str) or not api_token.strip():
+            raise ReserverBaseError(MISSING_API_TOKEN_ERROR)
         self.username = "__token__"
         self.password = api_token
         self.test_pypi = test_pypi

--- a/tests/test_reserver.py
+++ b/tests/test_reserver.py
@@ -66,6 +66,10 @@ def test_cwd_untouched(tmp_path, monkeypatch):
 
     monkeypatch.chdir(tmp_path)
 
+    # Snapshot the environment *before* the call. Reserver must leave it
+    # untouched (credentials are injected only into the subprocess env).
+    env_before = dict(os.environ)
+
     # Fake token is enough; we assert on cleanup, not on upload outcome details.
     uploader = PyPIUploader("pypi-fake-token-for-cwd-test", test_pypi=True)
     assert uploader.upload(target_name) == False
@@ -75,8 +79,7 @@ def test_cwd_untouched(tmp_path, monkeypatch):
     assert marker.exists()
     assert marker.read_text(encoding="utf-8") == marker_content
     assert [p.name for p in victim.iterdir()] == ["marker.txt"]
-    assert "TWINE_USERNAME" not in os.environ
-    assert "TWINE_PASSWORD" not in os.environ
+    assert dict(os.environ) == env_before
 
 
 @pytest.mark.end_to_end

--- a/tests/test_reserver.py
+++ b/tests/test_reserver.py
@@ -1,49 +1,91 @@
 import os
+from pathlib import Path
 import pytest
-from reserver import PyPIUploader
+from reserver import PyPIUploader, ReserverBaseError
 from reserver.functions import get_random_name
 
 pypi_token = os.environ.get("TWINE_PASSWORD")
 test_pypi_token = os.environ.get("TWINE_TEST_PASSWORD")
 
-def test_package_exists():
-    # test reserved name
+
+def test_taken_name():
+    # Reserving a name that already exists on (test) PyPI must fail.
     uploader = PyPIUploader(test_pypi_token, test_pypi=True)
     assert uploader.upload("numpy") == False
 
-def test_standard_module_conflict():
-    # try to reserve a standard python library module
+
+def test_stdlib_name():
+    # Reserving a Python standard-library module name must fail.
     uploader = PyPIUploader(test_pypi_token, test_pypi=True)
     assert uploader.upload("os") == False
 
-def test_valid_package_invalid_credentials():
-    # test not reserved name -> wrong credentials
+
+def test_wrong_token():
+    # A syntactically-valid but incorrect token must cause upload to fail.
     uploader = PyPIUploader("pypi-wrong-api-token", test_pypi=True)
     assert uploader.upload(get_random_name()) == False
 
+
 @pytest.mark.end_to_end
-def test_valid_package_valid_credentials():
-    # test not reserved name -> correct credentials
+def test_upload_success():
+    # Happy path: free name + correct token -> successful reservation.
     uploader = PyPIUploader(test_pypi_token, test_pypi=True)
     assert uploader.upload(get_random_name()) == True
 
+
 def test_module_conflict():
-    # try to reserve a name which conflicts with the module name of a previously taken package (the taken package itself has a different name, but it's module name has conflict)."
+    # Name collides with the importable module of a *different* existing
+    # package (e.g. project "X" ships module "freeze"). PyPI blocks this.
     uploader = PyPIUploader(test_pypi_token, test_pypi=True)
     assert uploader.upload("freeze") == False
 
-def test_batch_packages_names():
-    # test batch of package names
+
+def test_batch_all_taken():
+    # Batch of already-taken names -> zero successful reservations.
     uploader = PyPIUploader(test_pypi_token, test_pypi=True)
     assert uploader.batch_upload(["numpy", "scikit-learn"]) == 0
 
+
+@pytest.mark.parametrize("bad_token", [None, "", "   ", 123, b"pypi-bytes"])
+def test_invalid_token(bad_token):
+    # The library must refuse construction without a real token so callers
+    # cannot accidentally hit the network with empty credentials.
+    with pytest.raises(ReserverBaseError):
+        PyPIUploader(bad_token, test_pypi=True)
+
+
+def test_cwd_untouched(tmp_path, monkeypatch):
+    # Regression: upload() must NOT write into or delete a directory in the
+    # user's CWD that happens to share the target package name.
+    target_name = "numpy"  # taken -> twine will fail, exercising cleanup
+    victim = tmp_path / target_name
+    victim.mkdir()
+    marker = victim / "marker.txt"
+    marker_content = "user data - must not be touched"
+    marker.write_text(marker_content, encoding="utf-8")
+
+    monkeypatch.chdir(tmp_path)
+
+    # Fake token is enough; we assert on cleanup, not on upload outcome details.
+    uploader = PyPIUploader("pypi-fake-token-for-cwd-test", test_pypi=True)
+    assert uploader.upload(target_name) == False
+
+    assert Path.cwd() == tmp_path
+    assert victim.is_dir()
+    assert marker.exists()
+    assert marker.read_text(encoding="utf-8") == marker_content
+    assert [p.name for p in victim.iterdir()] == ["marker.txt"]
+    assert "TWINE_USERNAME" not in os.environ
+    assert "TWINE_PASSWORD" not in os.environ
+
+
 @pytest.mark.end_to_end
-def test_batch_upload():
-    # try to reserve two non taken package names with per package custom setup.py parameters
-    # make sure you are in "tests" directory
+def test_batch_success():
+    # Batch happy path: two free names with per-package custom params.
+    # Invoker must be in the repo root so that "tests/" is resolvable.
     tests_dir = os.path.join(os.getcwd(), "tests")
     uploader = PyPIUploader(test_pypi_token, test_pypi=True)
     assert uploader.batch_upload(
         [get_random_name(), get_random_name() + get_random_name()],
-        [os.path.join(tests_dir, "config.json"), os.path.join(tests_dir,"config2.json")]
-        ) == 2
+        [os.path.join(tests_dir, "config.json"), os.path.join(tests_dir, "config2.json")]
+    ) == 2


### PR DESCRIPTION
#### Reference Issues/PRs

#### What does this implement/fix? Explain your changes.
In this PR, I apply internal clean-up and refactoring to better cover corner cases, improve robustness.

- Token validation at construction so callers cannot reach the network with empty/invalid credentials.
- Regression tests covering token validation and CWD preservation.
- upload now builds the template package in an isolated temporary directory and restores CWD + cleans up via finally.
- Credentials are passed to twine via subprocess env= instead of mutating os.environ
- pre-existing TWINE_* are stripped to prevent external overrides.
- First subprocess failure is reported as-is (no longer overwritten by next commands).
- Template generators updated to reflect reserver's real Python support (>=3.7, 3.7–3.14).
- Default package metadata in params.py reworked to stop referencing unrelated third-party URLs/emails.
- Test names shortened and explanations moved to inline comments.

#### Any other comments?

